### PR TITLE
Add status conditions to Shim status

### DIFF
--- a/internal/controller/shim_controller.go
+++ b/internal/controller/shim_controller.go
@@ -189,7 +189,27 @@ func (sr *ShimReconciler) updateStatus(ctx context.Context, shim *kwasmv1.Shim, 
 		}
 	}
 
-	// TODO: include proper status conditions to update
+	if shim.Status.NodeReadyCount != shim.Status.NodeCount {
+		// Create a new condition to represent the shim's readiness
+		shimReady := metav1.Condition{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			LastTransitionTime: metav1.Now(),
+			Reason:             "ShimReady",
+			Message:            "Shim is ready",
+		}
+		shim.Status.Conditions = []metav1.Condition{shimReady}
+	} else {
+		// If not all nodes are ready, create the "Ready" condition with status false
+		shimReady := metav1.Condition{
+			Type:               "Ready",
+			Status:             metav1.ConditionFalse,
+			LastTransitionTime: metav1.Now(),
+			Reason:             "ShimNotReady",
+			Message:            fmt.Sprintf("Shim is not ready. Ready nodes: %d, Total nodes: %d", shim.Status.NodeReadyCount, shim.Status.NodeCount),
+		}
+		shim.Status.Conditions = []metav1.Condition{shimReady}
+	}
 
 	if err := sr.Update(ctx, shim); err != nil {
 		log.Error().Msgf("Unable to update status %s", err)


### PR DESCRIPTION
## Describe your changes

Implement status conditions in Shim status to reflect readiness based on node provisioning status. #51

## Issue ticket number and link

https://github.com/spinkube/runtime-class-manager/blob/c65f3562aabfca4681c034f09afd4d5a513ee732/internal/controller/shim_controller.go#L192

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [ ] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes