### PR TITLE
chore(*): bump spin shim to v0.19.0

### DIFF
--- a/.github/workflows/helm-chart-smoketest.yml
+++ b/.github/workflows/helm-chart-smoketest.yml
@@ -9,7 +9,7 @@ env:
   # For k3d in particular, containerd 2.0 is used starting with k3s image tag v1.32.2-k3s1
   K8S_VERSION: v1.32.1
   MICROK8S_CHANNEL: 1.32/stable
-  SHIM_SPIN_VERSION: v0.18.0
+  SHIM_SPIN_VERSION: v0.19.0
   DOCKER_BUILD_SUMMARY: false
 
 jobs:

--- a/config/samples/test_shim_spin.yaml
+++ b/config/samples/test_shim_spin.yaml
@@ -15,7 +15,7 @@ spec:
   fetchStrategy:
     type: anonymousHttp
     anonHttp:
-      location: "https://github.com/spinframework/containerd-shim-spin/releases/download/v0.15.1/containerd-shim-spin-v2-linux-aarch64.tar.gz"
+      location: "https://github.com/spinframework/containerd-shim-spin/releases/download/v0.19.0/containerd-shim-spin-v2-linux-aarch64.tar.gz"
 
   runtimeClass:
     # Note: this name is used by the Spin Operator project as its default:


### PR DESCRIPTION
## Describe your changes

Bumps the containerd-shim-spin version to [v0.19.0](https://github.com/spinframework/containerd-shim-spin/releases/tag/v0.19.0)

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [ ] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes