### PR TITLE
feat(containerd): support 2.x

### DIFF
--- a/.github/workflows/helm-chart-smoketest.yml
+++ b/.github/workflows/helm-chart-smoketest.yml
@@ -4,10 +4,7 @@ on:
   workflow_call:
 
 env:
-  # TODO: bump to a more recent K8S_VERSION once rcm supports containerd 2.0+
-  # see https://github.com/spinframework/runtime-class-manager/issues/371
-  # For k3d in particular, containerd 2.0 is used starting with k3s image tag v1.32.2-k3s1
-  K8S_VERSION: v1.32.1
+  K8S_VERSION: v1.32.3
   MICROK8S_CHANNEL: 1.32/stable
   SHIM_SPIN_VERSION: v0.19.0
   DOCKER_BUILD_SUMMARY: false

--- a/testdata/node-installer/containerd/1.x/etc/containerd/config.toml
+++ b/testdata/node-installer/containerd/1.x/etc/containerd/config.toml
@@ -1,0 +1,1 @@
+version = 2

--- a/testdata/node-installer/containerd/2.x/etc/containerd/config.toml
+++ b/testdata/node-installer/containerd/2.x/etc/containerd/config.toml
@@ -1,0 +1,1 @@
+version = 3


### PR DESCRIPTION
## Describe your changes

Updates generateConfig to support containerd 2.x (or, more accurately, containerd config syntax version 3).  More details at https://github.com/containerd/containerd/blob/release/2.0/docs/cri/config.md

## Issue ticket number and link

Closes https://github.com/spinframework/runtime-class-manager/issues/371

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [ ] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes