### PR TITLE
chore(shim_controller.go): remove unused SHIM_FETCH_STRATEGY env var

### DIFF
--- a/internal/controller/shim_controller.go
+++ b/internal/controller/shim_controller.go
@@ -440,10 +440,6 @@ func (sr *ShimReconciler) createJobManifest(shim *rcmv1.Shim, node *corev1.Node,
 								Name:  "HOST_ROOT",
 								Value: "/mnt/node-root",
 							},
-							{
-								Name:  "SHIM_FETCH_STRATEGY",
-								Value: "/mnt/node-root",
-							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{


### PR DESCRIPTION
Noticed this unused env var supplied to the node-installer's provisioner container (as opposed to its downloader init container).  Seems like it should be removed.