### PR TITLE
feat(*): add K8s distro-specific restarters; update default restarter

### DIFF
--- a/.github/workflows/helm-chart-smoketest.yml
+++ b/.github/workflows/helm-chart-smoketest.yml
@@ -158,13 +158,11 @@ jobs:
       - name: label nodes
         run: kubectl label node --all spin=true
 
-      # MicroK8s runs directly on the host, so both the host's containerd process and MicroK8s' would
-      # otherwise be detected by runtime-class-manager. As of writing, rcm will fail if more than one
-      # containerd process is detected when attempting to restart. So, we stop the host process until
-      # the shim has been installed and the test app has been confirmed to run.
-      - name: stop system containerd
-        if: matrix.config.type == 'microk8s'
-        run: sudo systemctl stop containerd
+      - name: verify only one installer pod with Succeeded status
+        # TODO: provisioning on k3d still leads to the first installer pod finishing with provisioner status Unknown and phase Failed
+        if: matrix.config.type != 'k3d'
+        run: |
+          timeout 60s bash -c 'until [[ "$(kubectl -n rcm get $(kubectl get pods -n rcm --no-headers -o name | grep install | head -n1) -o jsonpath="{.status.phase}" 2>/dev/null)" == "Succeeded" ]]; do sleep 2; done'
 
       - name: run Spin App
         run: |
@@ -186,7 +184,7 @@ jobs:
           kubectl describe runtimeclass wasmtime-spin-v2
 
           # Get install pod logs
-          # Note: there may be multiple pods pending fix in https://github.com/spinkube/runtime-class-manager/issues/140
+          # Note: there may be multiple pods pending k3d fix for issue https://github.com/spinkube/runtime-class-manager/issues/140
           install_pod=$(kubectl get pods -n rcm --no-headers -o name | awk '{if ($1 ~ "-spin-v2-install") print $0}' | tail -n 1)
           kubectl describe -n rcm $install_pod || true
           kubectl logs -n rcm -c downloader $install_pod || true

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 go build -o rcm-node-installer ./cmd/node-installer
 RUN /app/rcm-node-installer -h
 
 # Using busybox instead of scratch so that the nsenter utility is present, as used in restarter logic
-FROM busybox
+FROM busybox:1.37
 COPY --from=builder /app/rcm-node-installer /rcm-node-installer
 
 ENTRYPOINT ["/rcm-node-installer"]

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -10,7 +10,8 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o rcm-node-installer ./cmd/node-installer
 RUN /app/rcm-node-installer -h
 
-FROM scratch
+# Using busybox instead of scratch so that the nsenter utility is present, as used in restarter logic
+FROM busybox
 COPY --from=builder /app/rcm-node-installer /rcm-node-installer
 
 ENTRYPOINT ["/rcm-node-installer"]

--- a/internal/containerd/restart_unix.go
+++ b/internal/containerd/restart_unix.go
@@ -22,6 +22,9 @@ package containerd
 import (
 	"fmt"
 	"log/slog"
+	"os"
+	"os/exec"
+	"regexp"
 	"syscall"
 
 	"github.com/mitchellh/go-ps"
@@ -29,28 +32,136 @@ import (
 
 var psProcesses = ps.Processes
 
-type restarter struct{}
+type defaultRestarter struct{}
 
-func NewRestarter() Restarter {
-	return restarter{}
+func NewDefaultRestarter() Restarter {
+	return defaultRestarter{}
 }
 
-func (c restarter) Restart() error {
-	pid, err := getPid()
-	if err != nil {
-		return err
-	}
-	slog.Debug("found containerd process", "pid", pid)
+func (c defaultRestarter) Restart() error {
+	// If systemctl exists, use that, otherwise go pid
+	if UsesSystemd() {
+		out, err := nsenterCmd("systemctl", "restart", "containerd").CombinedOutput()
+		slog.Debug(string(out))
+		if err != nil {
+			return fmt.Errorf("unable to restart containerd: %w", err)
+		}
+	} else {
+		pid, err := getPid("containerd")
+		if err != nil {
+			return err
+		}
+		slog.Debug("found containerd process", "pid", pid)
 
-	err = syscall.Kill(pid, syscall.SIGHUP)
-
-	if err != nil {
-		return fmt.Errorf("failed to send SIGHUP to containerd: %w", err)
+		err = syscall.Kill(pid, syscall.SIGHUP)
+		if err != nil {
+			return fmt.Errorf("failed to send SIGHUP to containerd: %w", err)
+		}
 	}
+
 	return nil
 }
 
-func getPid() (int, error) {
+type K0sRestarter struct{}
+
+func (c K0sRestarter) Restart() error {
+	// First, collect systemd units to determine which mode k0s is running in, eg
+	// k0sworker or k0scontroller
+	units, err := nsenterCmd("systemctl", "list-units").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("unable to list systemd units: %w", err)
+	}
+	service := regexp.MustCompile("k0sworker|k0scontroller").FindString(string(units))
+
+	out, err := nsenterCmd("systemctl", "restart", service).CombinedOutput()
+	slog.Debug(string(out))
+	if err != nil {
+		return fmt.Errorf("unable to restart %s: %w", service, err)
+	}
+
+	return nil
+}
+
+type K3sRestarter struct{}
+
+func (c K3sRestarter) Restart() error {
+	// This restarter will be used both for stock K3s distros
+	// using systemd as well as K3d, which does not.
+	if UsesSystemd() {
+		out, err := nsenterCmd("systemctl", "restart", "k3s").CombinedOutput()
+		slog.Debug(string(out))
+		if err != nil {
+			return fmt.Errorf("unable to restart k3s: %w", err)
+		}
+	} else {
+		// TODO: this approach still leads to the behavior mentioned in https://github.com/spinframework/runtime-class-manager/issues/140:
+		// The first pod's provisioner container exits with code 255, leading to pod status Unknown,
+		// followed by the subsequent pod's provisioner container no-op-ing and finishing with status Completed.
+		pid, err := getPid("k3s")
+		if err != nil {
+			return err
+		}
+		slog.Debug("found k3s process", "pid", pid)
+
+		err = syscall.Kill(pid, syscall.SIGHUP)
+		if err != nil {
+			return fmt.Errorf("failed to send SIGHUP to k3s: %w", err)
+		}
+	}
+
+	return nil
+}
+
+type MicroK8sRestarter struct{}
+
+func (c MicroK8sRestarter) Restart() error {
+	out, err := nsenterCmd("systemctl", "restart", "snap.microk8s.daemon-containerd").CombinedOutput()
+	slog.Debug(string(out))
+	if err != nil {
+		return fmt.Errorf("unable to restart snap.microk8s.daemon-containerd: %w", err)
+	}
+
+	return nil
+}
+
+type RKE2Restarter struct{}
+
+func (c RKE2Restarter) Restart() error {
+	// First, collect systemd units to determine which mode rke2 is running in, eg
+	// rke2-agent or rke2-server
+	units, err := nsenterCmd("systemctl", "list-units").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("unable to list systemd units: %w", err)
+	}
+	service := regexp.MustCompile("rke2-agent|rke2-server").FindString(string(units))
+
+	out, err := nsenterCmd("systemctl", "restart", service).CombinedOutput()
+	slog.Debug(string(out))
+	if err != nil {
+		return fmt.Errorf("unable to restart %s: %w", service, err)
+	}
+
+	return nil
+}
+
+// TODO: lifted and amended from https://github.com/spinframework/runtime-class-manager/pull/387
+//
+// UsesSystemd checks if the system is using systemd
+func UsesSystemd() bool {
+	cmd := nsenterCmd("systemctl", "list-units", "|", "grep", "-q", "containerd.service")
+	if err := cmd.Run(); err != nil {
+		slog.Debug("Error with systemctl: \n", "error", err)
+		return false
+	}
+	return true
+}
+
+func nsenterCmd(cmd ...string) *exec.Cmd {
+	return exec.Command("nsenter",
+		append([]string{fmt.Sprintf("-m/%s/proc/1/ns/mnt", os.Getenv("HOST_ROOT")), "--"}, cmd...)...) // #nosec G204
+}
+
+func getPid(executable string) (int, error) {
 	processes, err := psProcesses()
 	if err != nil {
 		return 0, fmt.Errorf("could not get processes: %w", err)
@@ -59,13 +170,13 @@ func getPid() (int, error) {
 	var containerdProcesses = []ps.Process{}
 
 	for _, process := range processes {
-		if process.Executable() == "containerd" {
+		if process.Executable() == executable {
 			containerdProcesses = append(containerdProcesses, process)
 		}
 	}
 
 	if len(containerdProcesses) != 1 {
-		return 0, fmt.Errorf("need exactly one containerd process, found: %d", len(containerdProcesses))
+		return 0, fmt.Errorf("need exactly one %s process, found: %d", executable, len(containerdProcesses))
 	}
 
 	return containerdProcesses[0].Pid(), nil

--- a/internal/containerd/restart_unix_test.go
+++ b/internal/containerd/restart_unix_test.go
@@ -57,7 +57,7 @@ func Test_getPid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			psProcesses = tt.psProccessesMock
-			got, err := getPid()
+			got, err := getPid("containerd")
 
 			if tt.wantErr {
 				require.Error(t, err)


### PR DESCRIPTION
## Describe your changes

Adds K8s distro-specific restarters to ameliorate the behavior mentioned in https://github.com/spinframework/runtime-class-manager/issues/140.*

* The asterisk is that the `k0s` and `k3d` distros still see the same behavior, despite attempted improvements.  (Definite follow-up/rabbit hole fodder.)

However, I'm proposing we move forward with the functionality here for a few reasons:
1. K8s distro-specific restart logic could prove useful in other ways in the future and this lays the foundation for adding/amending them.
2. The `Unknown` container termination behavior _has_ been fixed for `kind`, `k3s`, `rke2`, `minikube` and `AKS`, out of the k8s distros I tested.  Also, a check has been added to our helm smoke test, which currently vets the fix for  `minikube`, `kind` and `microk8s` (we can add more distros in the future).

## Issue ticket number and link

https://github.com/spinframework/runtime-class-manager/issues/140

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [x] Kind
  - [x] MiniKube
  - [x] MicroK8s
  - [x] K3d*
  - [x] K0s*
  - [x] K3s
  - [x] Rancher RKE2
  - [x] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes