### PR TITLE
fix(Makefile): use correct env var for node installer image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ docker-build-shim-downloader: ## Build the shim-downloader image.
 
 .PHONY: docker-build-node-installer
 docker-build-node-installer: ## Build the node-installer image.
-	$(CONTAINER_TOOL) build -t ${SHIM_DOWNLOADER_IMAGE} -f ./images/installer/Dockerfile .
+	$(CONTAINER_TOOL) build -t ${SHIM_NODE_INSTALLER_IMAGE} -f ./images/installer/Dockerfile .
 
 .PHONY: docker-build-all
 docker-build-all: docker-build docker-build-shim-downloader docker-build-node-installer


### PR DESCRIPTION
## Describe your changes
😅 follow-up fix for https://github.com/spinframework/runtime-class-manager/pull/403

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [ ] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes