### PR TITLE
fix(sbom.yml): fix cosign usage

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -61,9 +61,7 @@ jobs:
       - name: Sign SBOM file
         run: |
           cosign sign-blob --yes \
-            --output-certificate ${{ inputs.image-name }}-sbom-${{ matrix.arch }}.spdx.cert \
-            --output-signature ${{ inputs.image-name }}-sbom-${{ matrix.arch }}.spdx.sig \
-            --use-signing-config=false \
+            --bundle ${{ inputs.image-name }}-sbom-${{ matrix.arch }}.spdx.bundle \
             ${{ inputs.image-name }}-sbom-${{ matrix.arch }}.spdx
 
       - name: Attach SBOM file in the container image


### PR DESCRIPTION
A recent cosign dependabot bump required a usage update.

See `Error: must provide --bundle with --signing-config or --use-signing-config` from https://github.com/spinframework/runtime-class-manager/actions/runs/18857713377/job/53809479658

~~Here I added `--use-signing-config=false` as I don't believe we have a config or bundle to supply -- but happy to change course if advised.~~  _Update: switched to specifying a bundle output via `--bundle` containing the signature and certificate, as suggested by @kate-goldenring_

Tested on fork eg https://github.com/vdice/runtime-class-manager/actions/runs/18858122185