### PR TITLE
chore(*): pin deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.24"
@@ -37,7 +37,7 @@ jobs:
     name: Golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.24"

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -44,13 +44,13 @@ jobs:
       digest: ${{ steps.setoutput.outputs.digest }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -70,7 +70,7 @@ jobs:
       - name: Build and push container image
         if: ${{ inputs.push-image }}
         id: build-image
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ inputs.docker-context }}
           file: ${{ inputs.dockerfile }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: "Dependency Review"
         uses: actions/dependency-review-action@40c09b7dc99638e5ddb0bfd91c1673effc064d8a # v4.8.1
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.

--- a/.github/workflows/helm-chart-node-scaling-test.yml
+++ b/.github/workflows/helm-chart-node-scaling-test.yml
@@ -11,21 +11,21 @@ jobs:
   helm-node-scaling-test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install helm
-        uses: Azure/setup-helm@v4
+        uses: Azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.15.4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build RCM
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: ./Dockerfile
@@ -37,7 +37,7 @@ jobs:
             runtime-class-manager:chart-test
 
       - name: Build node installer
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: ./images/installer/Dockerfile
@@ -49,7 +49,7 @@ jobs:
             node-installer:chart-test
 
       - name: Build shim downloader
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ./images/downloader
           file: ./images/downloader/Dockerfile
@@ -78,7 +78,7 @@ jobs:
           chmod +x kindscaler.sh
 
       - name: create kind cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0
         with:
           cluster_name: kind
           config: kind-config.yaml

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install helm
-        uses: Azure/setup-helm@v4
+        uses: Azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.16.3
 
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/helm-chart-smoketest.yml
+++ b/.github/workflows/helm-chart-smoketest.yml
@@ -31,16 +31,16 @@ jobs:
               file: "./images/installer/Dockerfile"
             }
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build ${{ matrix.config.name }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ matrix.config.context }}
           file: ${{ matrix.config.file }}
@@ -80,10 +80,10 @@ jobs:
             }
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install helm
-        uses: Azure/setup-helm@v4
+        uses: Azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.17.2
 
@@ -99,7 +99,7 @@ jobs:
       # Ref: https://github.com/orgs/community/discussions/25824
       - name: Create kind cluster
         if: matrix.config.type == 'kind'
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0
         with:
           cluster_name: kind
           # Versions lower than v0.27.0 encounter https://github.com/kubernetes-sigs/kind/issues/3795
@@ -117,13 +117,13 @@ jobs:
 
       - name: Create microk8s cluster
         if: matrix.config.type == 'microk8s'
-        uses: balchua/microk8s-actions@v0.4.3
+        uses: balchua/microk8s-actions@13f73436011eb4925c22526f64fb3ecdd81289a9 # v0.4.3
         with:
           channel: ${{ env.MICROK8S_CHANNEL }}
 
       - name: Create k3d cluster
         if: matrix.config.type == 'k3d'
-        uses: AbsaOSS/k3d-action@v2
+        uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
         with:
           cluster-name: k3s-default
           k3d-version: v5.8.3

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -35,7 +35,7 @@ jobs:
         uses: IAreKyleW00t/crane-installer@f693de8b27d89e6e9b3352a6d762a2a6db5869da # v4.0.4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/sign-image.yml
+++ b/.github/workflows/sign-image.yml
@@ -25,7 +25,7 @@ jobs:
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/images/downloader/Dockerfile
+++ b/images/downloader/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.2
+FROM alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
 
 RUN apk add --no-cache curl bash tar
 COPY download_shim.sh /download_shim.sh

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 go build -o rcm-node-installer ./cmd/node-installer
 RUN /app/rcm-node-installer -h
 
 # Using busybox instead of scratch so that the nsenter utility is present, as used in restarter logic
-FROM busybox:1.37
+FROM busybox:1.37@sha256:e3652a00a2fabd16ce889f0aa32c38eec347b997e73bd09e69c962ec7f8732ee
 COPY --from=builder /app/rcm-node-installer /rcm-node-installer
 
 ENTRYPOINT ["/rcm-node-installer"]

--- a/tilt.dockerfile
+++ b/tilt.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.2
+FROM alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
 WORKDIR /
 COPY ./bin/manager /manager
 


### PR DESCRIPTION
- chore(images): pin alpine:3.22.2 and busybox:1.37 to commit
- chore(.github): pin the following actions to their commits:
    - actions/checkout to v5.0.1
    - helm/kind-action to v1.13.0
    - docker/build-push-action to v6.18.0
    - docker/setup-buildx-action to v3.11.1
    - docker/setup-qemu-action to v3.7.0
    - docker/login-action to v3.6.0
    - Azure/setup-helm action to v4.3.1
    - AbsaOSS/k3d-action to v2.4.0
    - balchua/microk8s-actions to v0.4.3