### PR TITLE
chore(Makefile): bump controller-gen to v0.19.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.2.1
-CONTROLLER_TOOLS_VERSION ?= v0.16.3
+CONTROLLER_TOOLS_VERSION ?= v0.19.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.

--- a/config/crd/bases/runtime.spinkube.dev_shims.yaml
+++ b/config/crd/bases/runtime.spinkube.dev_shims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: shims.runtime.spinkube.dev
 spec:
   group: runtime.spinkube.dev


### PR DESCRIPTION
- Bumps controller-gen to v0.19.0
  - This also addresses the build/test failure seen in the go 1.25 bump PR (https://github.com/spinframework/runtime-class-manager/actions/runs/19865701233?pr=496) which appears to be due to https://github.com/golang/go/issues/74462 (or a variant thereof)