### PR TITLE
Update docker-push target to use IMG variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ docker-push: docker-push-runtime-class-manager ## Push the runtime-class-manager
 
 .PHONY: docker-push-%
 docker-push-%:
-	$(CONTAINER_TOOL) push $(REGISTRY)/$*:$(TAG)
+	$(CONTAINER_TOOL) push $(IMG)
 
 .PHONY: docker-push-all
 docker-push-all: docker-push docker-push-shim-downloader docker-push-node-installer


### PR DESCRIPTION
## Describe your changes
We wanted to `make docker-build docker-push IMG=...`  but it didn't take into account the IMG.
This PR fixes that.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [ ] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes