### PR TITLE
Add nodes and node.k8s.io/runtimeclasses permission for manager

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - update
+  - watch
+- apiGroups:
   - batch
   resources:
   - jobs
@@ -30,6 +38,16 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - node.k8s.io
+  resources:
+  - runtimeclasses
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
 - apiGroups:
   - runtime.spinkube.dev
   resources:

--- a/internal/controller/shim_controller.go
+++ b/internal/controller/shim_controller.go
@@ -70,6 +70,8 @@ type opConfig struct {
 //+kubebuilder:rbac:groups=runtime.spinkube.dev,resources=shims,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=runtime.spinkube.dev,resources=shims/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=runtime.spinkube.dev,resources=shims/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=list;watch;update
+//+kubebuilder:rbac:groups=node.k8s.io,resources=runtimeclasses,verbs=get;list;watch;create;patch
 
 // SetupWithManager sets up the controller with the Manager.
 func (sr *ShimReconciler) SetupWithManager(mgr ctrl.Manager) error {


### PR DESCRIPTION
## Describe your changes
Add kubebuilder annotations to allow the controller to access nodes (watch/list/update) and node.k8s.io/runtimeclasses (get/watch/list/create/patch). It enables us to deploy the controller through `make deploy` successfully.

## Issue ticket number and link
https://github.com/spinframework/runtime-class-manager/issues/548

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [x] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes