### PR TITLE
chore(dependency-review.yml): allow LicenseRef-scancode-google-patent-license-golang

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -29,7 +29,7 @@ jobs:
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always
-          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-3-Clause, BSL-1.0, CC0-1.0, ISC, MIT, MPL-2.0, Unlicense
+          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-3-Clause, BSL-1.0, CC0-1.0, ISC, MIT, MPL-2.0, Unlicense, LicenseRef-scancode-google-patent-license-golang
         #   fail-on-severity: moderate
         #   deny-licenses: GPL-1.0-or-later, LGPL-2.0-or-later
         #   retry-on-snapshot-warnings: true


### PR DESCRIPTION
## Describe your changes

Allows the `LicenseRef-scancode-google-patent-license-golang` license in our dependency review workflow, needed to pull in more recent k8s.io package versions (eg https://github.com/spinframework/runtime-class-manager/pull/539)

## Issue ticket number and link

Closes https://github.com/spinframework/runtime-class-manager/issues/527
