### PR TITLE
Bump CI and example Shim to use containerd-shim-spin v0.22.0

### DIFF
--- a/.github/workflows/helm-chart-node-scaling-test.yml
+++ b/.github/workflows/helm-chart-node-scaling-test.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  SHIM_SPIN_VERSION: v0.19.0
+  SHIM_SPIN_VERSION: v0.22.0
   DOCKER_BUILD_SUMMARY: false
 
 jobs:

--- a/.github/workflows/helm-chart-smoketest.yml
+++ b/.github/workflows/helm-chart-smoketest.yml
@@ -9,7 +9,7 @@ permissions:
 env:
   K8S_VERSION: v1.32.3
   MICROK8S_CHANNEL: 1.32/stable
-  SHIM_SPIN_VERSION: v0.19.0
+  SHIM_SPIN_VERSION: v0.22.0
   DOCKER_BUILD_SUMMARY: false
 
 jobs:

--- a/config/samples/test_shim_spin.yaml
+++ b/config/samples/test_shim_spin.yaml
@@ -15,7 +15,7 @@ spec:
   fetchStrategy:
     type: anonymousHttp
     anonHttp:
-      location: "https://github.com/spinframework/containerd-shim-spin/releases/download/v0.19.0/containerd-shim-spin-v2-linux-aarch64.tar.gz"
+      location: "https://github.com/spinframework/containerd-shim-spin/releases/download/v0.22.0/containerd-shim-spin-v2-linux-aarch64.tar.gz"
 
   # Each runtime can provide a set of containerd runtime options to be set in the containerd
   # configuration file.


### PR DESCRIPTION
## Describe your changes
We are currently installing a fairly old containerd-shim-spin.

## Issue ticket number and link

## Checklist before requesting a review
CI going green should be sufficient