### PR TITLE
Add separate sample Shim files for each architecture for Spin and Wastime shims

### DIFF
--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -4,4 +4,8 @@ resources:
 - test_shim_slight.yaml
 - test_shim_spin.yaml
 - test_shim_wws.yaml
+- sample_shim_spin_x86_64.yaml
+- sample_shim_spin_aarch64.yaml
+- sample_shim_wasmtime_x86_64.yaml
+- sample_shim_wasmtime_aarch64.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/sample_shim_spin_aarch64.yaml
+++ b/config/samples/sample_shim_spin_aarch64.yaml
@@ -1,0 +1,35 @@
+apiVersion: runtime.spinkube.dev/v1alpha1 
+kind: Shim
+metadata:
+  name: spin-v2
+  labels:
+    app.kubernetes.io/name: spin-v2
+    app.kubernetes.io/instance: spin-v2
+    app.kubernetes.io/part-of: runtime-class-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: runtime-class-manager
+spec:
+  nodeSelector:
+    spin: "true"
+
+  fetchStrategy:
+    type: anonymousHttp
+    anonHttp:
+      location: "https://github.com/spinframework/containerd-shim-spin/releases/download/v0.22.0/containerd-shim-spin-v2-linux-aarch64.tar.gz"
+
+  # Each runtime can provide a set of containerd runtime options to be set in the containerd
+  # configuration file.
+  containerdRuntimeOptions:
+    # The following option to pass cgroup driver information is available to runwasi based runtimes.
+    # For runwasi, the default cgroup driver is cgroupfs. Failure to configure the correct cgroup
+    # driver for runwasi shims may result in pod metrics failing to propagate accurately.
+    SystemdCgroup: "true"
+
+  runtimeClass:
+    # Note: this name is used by the Spin Operator project as its default:
+    # https://github.com/spinframework/spin-operator/blob/main/config/samples/spin-shim-executor.yaml
+    name: wasmtime-spin-v2
+    handler: spin-v2
+
+  rolloutStrategy:
+    type: recreate

--- a/config/samples/sample_shim_spin_x86_64.yaml
+++ b/config/samples/sample_shim_spin_x86_64.yaml
@@ -1,0 +1,34 @@
+apiVersion: runtime.spinkube.dev/v1alpha1 
+kind: Shim
+metadata:
+  name: spin-v2
+  labels:
+    app.kubernetes.io/name: spin-v2
+    app.kubernetes.io/instance: spin-v2
+    app.kubernetes.io/part-of: runtime-class-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: runtime-class-manager
+spec:
+  nodeSelector:
+    spin: "true"
+
+  fetchStrategy:
+    type: anonymousHttp
+    anonHttp:
+      location: "https://github.com/spinframework/containerd-shim-spin/releases/download/v0.22.0/containerd-shim-spin-v2-linux-x86_64.tar.gz"
+  # Each runtime can provide a set of containerd runtime options to be set in the containerd
+  # configuration file.
+  containerdRuntimeOptions:
+    # The following option to pass cgroup driver information is available to runwasi based runtimes.
+    # For runwasi, the default cgroup driver is cgroupfs. Failure to configure the correct cgroup
+    # driver for runwasi shims may result in pod metrics failing to propagate accurately.
+    SystemdCgroup: "true"
+
+  runtimeClass:
+    # Note: this name is used by the Spin Operator project as its default:
+    # https://github.com/spinframework/spin-operator/blob/main/config/samples/spin-shim-executor.yaml
+    name: wasmtime-spin-v2
+    handler: spin-v2
+
+  rolloutStrategy:
+    type: recreate

--- a/config/samples/sample_shim_wasmtime_aarch64.yaml
+++ b/config/samples/sample_shim_wasmtime_aarch64.yaml
@@ -1,0 +1,25 @@
+apiVersion: runtime.spinkube.dev/v1alpha1 
+kind: Shim
+metadata:
+  name: wasmtime-v1
+  labels:
+    app.kubernetes.io/name: wasmtime-v1
+    app.kubernetes.io/instance: wasmtime-v1
+    app.kubernetes.io/part-of: runtime-class-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: runtime-class-manager
+spec:
+  nodeSelector:
+    wasmtime: "true"
+
+  fetchStrategy:
+    type: anonymousHttp
+    anonHttp:
+      location: "https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmtime%2Fv0.6.0/containerd-shim-wasmtime-aarch64-linux-musl.tar.gz"
+
+  runtimeClass:
+    name: wasmtime-v1
+    handler: wasmtime
+
+  rolloutStrategy:
+    type: recreate

--- a/config/samples/sample_shim_wasmtime_x86_64.yaml
+++ b/config/samples/sample_shim_wasmtime_x86_64.yaml
@@ -1,0 +1,25 @@
+apiVersion: runtime.spinkube.dev/v1alpha1 
+kind: Shim
+metadata:
+  name: wasmtime-v1
+  labels:
+    app.kubernetes.io/name: wasmtime-v1
+    app.kubernetes.io/instance: wasmtime-v1
+    app.kubernetes.io/part-of: runtime-class-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: runtime-class-manager
+spec:
+  nodeSelector:
+    wasmtime: "true"
+
+  fetchStrategy:
+    type: anonymousHttp
+    anonHttp:
+      location: "https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmtime%2Fv0.6.0/containerd-shim-wasmtime-x86_64-linux-musl.tar.gz"
+
+  runtimeClass:
+    name: wasmtime-v1
+    handler: wasmtime
+
+  rolloutStrategy:
+    type: recreate

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -6,10 +6,10 @@ Create one or more Wasm Shim custom resources. See the samples in https://github
 
 > Note: Ensure that the `location` for the specified shim binary points to the correct architecture for your Node(s)
 
-For example, install the Spin shim:
+For example, install the Spin shim on nodes with x86_64 architecture:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/spinframework/runtime-class-manager/refs/heads/main/config/samples/test_shim_spin.yaml
+ARCH=x86_64 kubectl apply -f https://raw.githubusercontent.com/spinframework/runtime-class-manager/refs/heads/main/config/samples/sample_shim_spin_$ARCH.yaml
 ```
 
 Next, annotate one or more nodes with a label corresponding to the `nodeSelector` declared in the Shim, runtime-class-manager will install the shim as well as create the corresponding RuntimeClass:


### PR DESCRIPTION
closes https://github.com/spinframework/runtime-class-manager/issues/576 by making it easier to install a specific arch of the shim. On release in the `Notes.txt`, we should point to tagged references of the example file rather than referencing main. see https://github.com/spinframework/runtime-class-manager/issues/580.

Also adds in Wasmtime shim example.