### PR TITLE
ci(smoketest): bump wait to 90s; see if it helps minikube variant pass consistently

### DIFF
--- a/.github/workflows/helm-chart-smoketest.yml
+++ b/.github/workflows/helm-chart-smoketest.yml
@@ -183,7 +183,7 @@ jobs:
           kubectl rollout status deployment wasm-spin --timeout 180s
           kubectl get pods -A
           kubectl port-forward svc/wasm-spin 8083:80 &
-          timeout 60s bash -c 'until curl -f -vvv http://localhost:8083/hello; do sleep 2; done'
+          timeout 90s bash -c 'until curl -f -vvv http://localhost:8083/hello; do sleep 2; done'
 
       - name: restart system containerd
         if: matrix.config.type == 'microk8s'


### PR DESCRIPTION
## Describe your changes

- Bumps the wait for the spin app to be ready from 60s to 90s; a first try to see if the flaky minikube test will succeed consistently

## Issue ticket number and link

https://github.com/spinframework/runtime-class-manager/issues/464
