### PR TITLE
fix(containerd): update k3s systemd unit restart to support agent mode

### DIFF
--- a/internal/containerd/restart_unix.go
+++ b/internal/containerd/restart_unix.go
@@ -20,6 +20,7 @@
 package containerd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -89,11 +90,23 @@ func (c K3sRestarter) Restart() error {
 	// This restarter will be used both for stock K3s distros, which use systemd as well as K3d, which does not.
 
 	// If listing systemd units succeeds, prefer systemctl restart; otherwise kill pid
-	if _, err := ListSystemdUnits(); err == nil {
-		out, err := nsenterCmd("systemctl", "restart", "k3s").CombinedOutput()
+	// First, collect systemd units to determine which k3s service to restart
+	if units, err := ListSystemdUnits(); err == nil {
+		var service string
+		// Prioritize k3s-agent (more common); otherwise k3s
+		switch {
+		case bytes.Contains(units, []byte("k3s-agent.service")):
+			service = "k3s-agent"
+		case bytes.Contains(units, []byte("k3s.service")):
+			service = "k3s"
+		default:
+			return fmt.Errorf("failed to find a registered k3s systemd service")
+		}
+
+		out, err := nsenterCmd("systemctl", "restart", service).CombinedOutput()
 		slog.Debug(string(out))
 		if err != nil {
-			return fmt.Errorf("unable to restart k3s: %w", err)
+			return fmt.Errorf("unable to restart the %s systemd service: %w", service, err)
 		}
 	} else {
 		// TODO: this approach still leads to the behavior mentioned in https://github.com/spinframework/runtime-class-manager/issues/140:


### PR DESCRIPTION
## Describe your changes

Updates the k3s restart logic when systemd units are used to check if either `k3s` or `k3s-agent` is the registered service.

https://github.com/spinframework/runtime-class-manager/issues/620 has more detail, but essentially most real-world k3s clusters use the latter `k3s-agent` service while quickstart/minimal k3s deployments (eg `curl -sfL https://get.k3s.io | sh -`) use `k3s`.

Note the TODO around allowing specification of the registered service, as it appears the k3s installer script allows customization.  This should be a separate follow-up if deemed necessary.

## Issue ticket number and link

https://github.com/spinframework/runtime-class-manager/issues/620

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [ ] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes