### PR TITLE
chore(*): bump go to 1.26.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25.5"
+          go-version: "1.26.1"
       - run: make test
 
   golangci:
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25.5"
+          go-version: "1.26.1"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.5.0
+          version: v2.11.4
           skip-cache: true

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.5.0
+GOLANGCI_LINT_VERSION ?= v2.11.4
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spinframework/runtime-class-manager
 
-go 1.25.5
+go 1.26.1
 
 require (
 	github.com/mitchellh/go-ps v1.0.0


### PR DESCRIPTION
- Bumps go to 1.26.1
- Bumps golangci-lint to [v2.11.4](https://github.com/golangci/golangci-lint/releases/tag/v2.11.4)

[CI started squawking](https://github.com/spinframework/runtime-class-manager/actions/runs/23806646444/job/69381860974?pr=646) per the upstream controller-runtime/setup-envtest we use (now requires 1.26+); I figured that was as good excuse as any.